### PR TITLE
Added entrypoint hooks to extend this image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,41 +2,51 @@ FROM java:openjdk-7-jre
 
 MAINTAINER zsx <thinkernel@gmail.com>
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    libcgi-pm-perl \
-    gitweb \
-  && rm -rf /var/lib/apt/lists/*
+# Overridable defaults
 ENV GERRIT_HOME /var/gerrit
 ENV GERRIT_SITE ${GERRIT_HOME}/review_site
 ENV GERRIT_WAR ${GERRIT_HOME}/gerrit.war
 ENV GERRIT_VERSION 2.11.3
 ENV GERRIT_USER gerrit2
+ENV GERRIT_INIT_ARGS ""
 
-RUN useradd -m -d "$GERRIT_HOME" -u 1000 -U  -s /bin/bash $GERRIT_USER
+# Add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN useradd -m -d "$GERRIT_HOME" -U $GERRIT_USER
+
+# Grab gosu for easy step-down from root
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+	gitweb \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN mkdir /docker-entrypoint-init.d
 
 #Download gerrit.war
 RUN curl -L https://gerrit-releases.storage.googleapis.com/gerrit-${GERRIT_VERSION}.war -o $GERRIT_WAR
 #Only for local test
 #COPY gerrit-${GERRIT_VERSION}.war $GERRIT_WAR
 
-COPY gerrit-entrypoint.sh ${GERRIT_HOME}/
-COPY gerrit-start.sh ${GERRIT_HOME}/
-
-RUN chmod +x ${GERRIT_HOME}/gerrit*.sh
-
-USER $GERRIT_USER
+# Ensure the entrypoint scripts are in a fixed location
+COPY gerrit-entrypoint.sh /
+COPY gerrit-start.sh /
+RUN chmod +x /gerrit*.sh
 
 #A directory has to be created before a volume is mounted to it.
 #So gerrit user can own this directory.
-RUN mkdir -p $GERRIT_SITE
+RUN gosu ${GERRIT_USER} mkdir -p $GERRIT_SITE
 
 #Gerrit site directory is a volume, so configuration and repositories
 #can be persisted and survive image upgrades.
 VOLUME $GERRIT_SITE
 
-ENTRYPOINT ["/var/gerrit/gerrit-entrypoint.sh"]
+ENTRYPOINT ["/gerrit-entrypoint.sh"]
 
 EXPOSE 8080 29418
 
-CMD ["/var/gerrit/gerrit-start.sh"]
+CMD ["/gerrit-start.sh"]
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@
 
     `docker run -d -v ~/gerrit_volume:/var/gerrit/review_site -p 8080:8080 -p 29418:29418 openfrontier/gerrit`
 
+## Install plugins on start.
+  When calling gerrit init --batch, it is possible to list plugins to be installed with --install-plugin=<plugin_name>. This can be done using the GERRIT_INIT_ARGS environment variable. See [Gerrit Documentation](https://gerrit-documentation.storage.googleapis.com/Documentation/2.11.3/pgm-init.html) for more information.
+
+## Extend this image.
+  Similarly to the [Postgres](https://hub.docker.com/_/postgres/) image, if you would like to do additional configuration mid-script, add one or more
+  `*.sh` scripts under `/docker-entrypoint-init.d`. This directory is created by default. Scripts in `/docker-entrypoint-init.d` are run after gerrit
+  has been initialized, but before any of the gerrit config is customized, allowing you to programmatically override environment variables in entrypoint
+  scripts.
+
 ## Run dockerized gerrit with dockerized PostgreSQL and OpenLDAP.
 #####All attributes in [gerrit.config ldap section](https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#ldap) is supported.
 

--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -1,99 +1,122 @@
 #!/bin/bash
 set -e
+
+function set_gerrit_config {
+  gosu ${GERRIT_USER} git config -f "${GERRIT_SITE}/etc/gerrit.config" $@
+}
+
+function set_secure_config {
+  gosu ${GERRIT_USER} git config -f "${GERRIT_SITE}/etc/secure.config" $@
+}
+
 #Initialize gerrit if gerrit site dir is empty.
 #This is necessary when gerrit site is in a volume.
-if [ "$1" = '/var/gerrit/gerrit-start.sh' ]; then
+if [ "$1" = "/gerrit-start.sh" ]; then
+  # If you're mounting ${GERRIT_SITE} to your host, you this will default to root.
+  # This obviously ensures the permissions are set correctly for when gerrit starts.
+  chown -R ${GERRIT_USER} "${GERRIT_SITE}"
+
   if [ -z "$(ls -A "$GERRIT_SITE")" ]; then
     echo "First time initialize gerrit..."
-    java -jar "${GERRIT_WAR}" init --batch --no-auto-start -d "${GERRIT_SITE}"
+    gosu ${GERRIT_USER} java -jar "${GERRIT_WAR}" init --batch --no-auto-start -d "${GERRIT_SITE}" ${GERRIT_INIT_ARGS}
     #All git repositories must be removed in order to be recreated at the secondary init below.
     rm -rf "${GERRIT_SITE}/git"
   fi
 
+  # Provide a way to customise this image
+  echo
+  for f in /docker-entrypoint-init.d/*; do
+    case "$f" in
+      *.sh)  echo "$0: running $f"; . "$f" ;;
+      *)     echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
+
   #Customize gerrit.config
 
   #Section gerrit
-  [ -z "${WEBURL}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" gerrit.canonicalWebUrl "${WEBURL}"
+  [ -z "${WEBURL}" ] || set_gerrit_config gerrit.canonicalWebUrl "${WEBURL}"
 
   #Section database
   if [ "${DATABASE_TYPE}" = 'postgresql' ]; then
-    git config -f "${GERRIT_SITE}/etc/gerrit.config" database.type "${DATABASE_TYPE}"
-    [ -z "${DB_PORT_5432_TCP_ADDR}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.hostname "${DB_PORT_5432_TCP_ADDR}"
-    [ -z "${DB_PORT_5432_TCP_PORT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.port "${DB_PORT_5432_TCP_PORT}"
-    [ -z "${DB_ENV_POSTGRES_DB}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.database "${DB_ENV_POSTGRES_DB}"
-    [ -z "${DB_ENV_POSTGRES_USER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.username "${DB_ENV_POSTGRES_USER}"
-    [ -z "${DB_ENV_POSTGRES_PASSWORD}" ] || git config -f "${GERRIT_SITE}/etc/secure.config" database.password "${DB_ENV_POSTGRES_PASSWORD}"
+    set_gerrit_config database.type "${DATABASE_TYPE}"
+    [ -z "${DB_PORT_5432_TCP_ADDR}" ]    || set_gerrit_config database.hostname "${DB_PORT_5432_TCP_ADDR}"
+    [ -z "${DB_PORT_5432_TCP_PORT}" ]    || set_gerrit_config database.port "${DB_PORT_5432_TCP_PORT}"
+    [ -z "${DB_ENV_POSTGRES_DB}" ]       || set_gerrit_config database.database "${DB_ENV_POSTGRES_DB}"
+    [ -z "${DB_ENV_POSTGRES_USER}" ]     || set_gerrit_config database.username "${DB_ENV_POSTGRES_USER}"
+    [ -z "${DB_ENV_POSTGRES_PASSWORD}" ] || set_secure_config database.password "${DB_ENV_POSTGRES_PASSWORD}"
   fi
 
   #Section database
   if [ "${DATABASE_TYPE}" = 'mysql' ]; then
-    git config -f "${GERRIT_SITE}/etc/gerrit.config" database.type "${DATABASE_TYPE}"
-    [ -z "${DB_PORT_3306_TCP_ADDR}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.hostname "${DB_PORT_3306_TCP_ADDR}"
-    [ -z "${DB_PORT_3306_TCP_PORT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.port "${DB_PORT_3306_TCP_PORT}"
-    [ -z "${DB_ENV_MYSQL_DB}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.database "${DB_ENV_MYSQL_DB}"
-    [ -z "${DB_ENV_MYSQL_USER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" database.username "${DB_ENV_MYSQL_USER}"
-    [ -z "${DB_ENV_MYSQL_PASSWORD}" ] || git config -f "${GERRIT_SITE}/etc/secure.config" database.password "${DB_ENV_MYSQL_PASSWORD}"
+    set_gerrit_config database.type "${DATABASE_TYPE}"
+    [ -z "${DB_PORT_3306_TCP_ADDR}" ] || set_gerrit_config database.hostname "${DB_PORT_3306_TCP_ADDR}"
+    [ -z "${DB_PORT_3306_TCP_PORT}" ] || set_gerrit_config database.port "${DB_PORT_3306_TCP_PORT}"
+    [ -z "${DB_ENV_MYSQL_DB}" ]       || set_gerrit_config database.database "${DB_ENV_MYSQL_DB}"
+    [ -z "${DB_ENV_MYSQL_USER}" ]     || set_gerrit_config database.username "${DB_ENV_MYSQL_USER}"
+    [ -z "${DB_ENV_MYSQL_PASSWORD}" ] || set_secure_config database.password "${DB_ENV_MYSQL_PASSWORD}"
   fi
 
   #Section ldap
   if [ "${AUTH_TYPE}" = 'LDAP' ]; then
-    git config -f "${GERRIT_SITE}/etc/gerrit.config" auth.type "${AUTH_TYPE}"
-    git config -f "${GERRIT_SITE}/etc/gerrit.config" auth.gitBasicAuth true
-    [ -z "${LDAP_SERVER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.server "ldap://${LDAP_SERVER}"
-    [ -z "${LDAP_SSLVERIFY}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.sslVerify "${LDAP_SSLVERIFY}"
-    [ -z "${LDAP_GROUPSVISIBLETOALL}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupsVisibleToAll "${LDAP_GROUPSVISIBLETOALL}"
-    [ -z "${LDAP_USERNAME}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.username "${LDAP_USERNAME}"
-    [ -z "${LDAP_PASSWORD}" ] || git config -f "${GERRIT_SITE}/etc/secure.config" ldap.password "${LDAP_PASSWORD}"
-    [ -z "${LDAP_REFERRAL}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.referral "${LDAP_REFERRAL}"
-    [ -z "${LDAP_READTIMEOUT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.readTimeout "${LDAP_READTIMEOUT}"
-    [ -z "${LDAP_ACCOUNTBASE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountBase "${LDAP_ACCOUNTBASE}"
-    [ -z "${LDAP_ACCOUNTSCOPE}" ] || git config -f  "${GERRIT_SITE}/etc/gerrit.config" ldap.accountScope "${LDAP_ACCOUNTSCOPE}"
-    [ -z "${LDAP_ACCOUNTPATTERN}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountPattern "${LDAP_ACCOUNTPATTERN}"
-    [ -z "${LDAP_ACCOUNTFULLNAME}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountFullName "${LDAP_ACCOUNTFULLNAME}"
-    [ -z "${LDAP_ACCOUNTEMAILADDRESS}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountEmailAddress "${LDAP_ACCOUNTEMAILADDRESS}"
-    [ -z "${LDAP_ACCOUNTSSHUSERNAME}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountSshUserName "${LDAP_ACCOUNTSSHUSERNAME}"
-    [ -z "${LDAP_ACCOUNTMEMBERFIELD}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.accountMemberField "${LDAP_ACCOUNTMEMBERFIELD}"
-    [ -z "${LDAP_FETCHMEMBEROFEAGERLY}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.fetchMemberOfEagerly "${LDAP_FETCHMEMBEROFEAGERLY}"
-    [ -z "${LDAP_GROUPBASE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupBase "${LDAP_GROUPBASE}"
-    [ -z "${LDAP_GROUPSCOPE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupScope "${LDAP_GROUPSCOPE}"
-    [ -z "${LDAP_GROUPPATTERN}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupPattern "${LDAP_GROUPPATTERN}"
-    [ -z "${LDAP_GROUPMEMBERPATTERN}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupMemberPattern "${LDAP_GROUPMEMBERPATTERN}"
-    [ -z "${LDAP_GROUPNAME}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupName "${LDAP_GROUPNAME}"
-    [ -z "${LDAP_LOCALUSERNAMETOLOWERCASE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.localUsernameToLowerCase "${LDAP_LOCALUSERNAMETOLOWERCASE}"
-    [ -z "${LDAP_AUTHENTICATION}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.authentication "${LDAP_AUTHENTICATION}"
-    [ -z "${LDAP_USECONNECTIONPOOLING}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.useConnectionPooling "${LDAP_USECONNECTIONPOOLING}"
-    [ -z "${LDAP_CONNECTTIMEOUT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.connectTimeout "${LDAP_CONNECTTIMEOUT}"
+    set_gerrit_config auth.type "${AUTH_TYPE}"
+    set_gerrit_config auth.gitBasicAuth true
+    [ -z "${LDAP_SERVER}" ]                   || set_gerrit_config ldap.server "ldap://${LDAP_SERVER}"
+    [ -z "${LDAP_SSLVERIFY}" ]                || set_gerrit_config ldap.sslVerify "${LDAP_SSLVERIFY}"
+    [ -z "${LDAP_GROUPSVISIBLETOALL}" ]       || set_gerrit_config ldap.groupsVisibleToAll "${LDAP_GROUPSVISIBLETOALL}"
+    [ -z "${LDAP_USERNAME}" ]                 || set_gerrit_config ldap.username "${LDAP_USERNAME}"
+    [ -z "${LDAP_PASSWORD}" ]                 || set_secure_config ldap.password "${LDAP_PASSWORD}"
+    [ -z "${LDAP_REFERRAL}" ]                 || set_gerrit_config ldap.referral "${LDAP_REFERRAL}"
+    [ -z "${LDAP_READTIMEOUT}" ]              || set_gerrit_config ldap.readTimeout "${LDAP_READTIMEOUT}"
+    [ -z "${LDAP_ACCOUNTBASE}" ]              || set_gerrit_config ldap.accountBase "${LDAP_ACCOUNTBASE}"
+    [ -z "${LDAP_ACCOUNTSCOPE}" ]             || set_gerrit_config ldap.accountScope "${LDAP_ACCOUNTSCOPE}"
+    [ -z "${LDAP_ACCOUNTPATTERN}" ]           || set_gerrit_config ldap.accountPattern "${LDAP_ACCOUNTPATTERN}"
+    [ -z "${LDAP_ACCOUNTFULLNAME}" ]          || set_gerrit_config ldap.accountFullName "${LDAP_ACCOUNTFULLNAME}"
+    [ -z "${LDAP_ACCOUNTEMAILADDRESS}" ]      || set_gerrit_config ldap.accountEmailAddress "${LDAP_ACCOUNTEMAILADDRESS}"
+    [ -z "${LDAP_ACCOUNTSSHUSERNAME}" ]       || set_gerrit_config ldap.accountSshUserName "${LDAP_ACCOUNTSSHUSERNAME}"
+    [ -z "${LDAP_ACCOUNTMEMBERFIELD}" ]       || set_gerrit_config ldap.accountMemberField "${LDAP_ACCOUNTMEMBERFIELD}"
+    [ -z "${LDAP_FETCHMEMBEROFEAGERLY}" ]     || set_gerrit_config ldap.fetchMemberOfEagerly "${LDAP_FETCHMEMBEROFEAGERLY}"
+    [ -z "${LDAP_GROUPBASE}" ]                || set_gerrit_config ldap.groupBase "${LDAP_GROUPBASE}"
+    [ -z "${LDAP_GROUPSCOPE}" ]               || set_gerrit_config ldap.groupScope "${LDAP_GROUPSCOPE}"
+    [ -z "${LDAP_GROUPPATTERN}" ]             || set_gerrit_config ldap.groupPattern "${LDAP_GROUPPATTERN}"
+    [ -z "${LDAP_GROUPMEMBERPATTERN}" ]       || set_gerrit_config ldap.groupMemberPattern "${LDAP_GROUPMEMBERPATTERN}"
+    [ -z "${LDAP_GROUPNAME}" ]                || set_gerrit_config ldap.groupName "${LDAP_GROUPNAME}"
+    [ -z "${LDAP_LOCALUSERNAMETOLOWERCASE}" ] || set_gerrit_config ldap.localUsernameToLowerCase "${LDAP_LOCALUSERNAMETOLOWERCASE}"
+    [ -z "${LDAP_AUTHENTICATION}" ]           || set_gerrit_config ldap.authentication "${LDAP_AUTHENTICATION}"
+    [ -z "${LDAP_USECONNECTIONPOOLING}" ]     || set_gerrit_config ldap.useConnectionPooling "${LDAP_USECONNECTIONPOOLING}"
+    [ -z "${LDAP_CONNECTTIMEOUT}" ]           || set_gerrit_config ldap.connectTimeout "${LDAP_CONNECTTIMEOUT}"
   fi
 
   # section container
-  [ -z "${JAVA_HEAPLIMIT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" container.heapLimit "${JAVA_HEAPLIMIT}"
-  [ -z "${JAVA_OPTIONS}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" container.javaOptions "${JAVA_OPTIONS}"
-  [ -z "${JAVA_SLAVE}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" container.slave "${JAVA_SLAVE}"
+  [ -z "${JAVA_HEAPLIMIT}" ] || set_gerrit_config container.heapLimit "${JAVA_HEAPLIMIT}"
+  [ -z "${JAVA_OPTIONS}" ]   || set_gerrit_config container.javaOptions "${JAVA_OPTIONS}"
+  [ -z "${JAVA_SLAVE}" ]     || set_gerrit_config container.slave "${JAVA_SLAVE}"
 
   #Section sendemail
   if [ -z "${SMTP_SERVER}" ]; then
-    git config -f "${GERRIT_SITE}/etc/gerrit.config" sendemail.enable false
+    set_gerrit_config sendemail.enable false
   else
-    git config -f "${GERRIT_SITE}/etc/gerrit.config" sendemail.smtpServer "${SMTP_SERVER}"
+    set_gerrit_config sendemail.smtpServer "${SMTP_SERVER}"
     if [ "smtp.gmail.com" = "${SMTP_SERVER}" ]; then
       echo "gmail detected, using default port and encryption"
-      git config -f "${GERRIT_SITE}/etc/gerrit.config" sendemail.smtpServerPort 587
-      git config -f "${GERRIT_SITE}/etc/gerrit.config" sendemail.smtpEncryption tls
+      set_gerrit_config sendemail.smtpServerPort 587
+      set_gerrit_config sendemail.smtpEncryption tls
     fi
-    [ -z "${SMTP_SERVER_PORT}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" sendemail.smtpServerPort "${SMTP_SERVER_PORT}"
-    [ -z "${SMTP_USER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" sendemail.smtpUser "${SMTP_USER}"
-    [ -z "${SMTP_PASS}" ] || git config -f "${GERRIT_SITE}/etc/secure.config" sendemail.smtpPass "${SMTP_PASS}"
+    [ -z "${SMTP_SERVER_PORT}" ] || set_gerrit_config sendemail.smtpServerPort "${SMTP_SERVER_PORT}"
+    [ -z "${SMTP_USER}" ]        || set_gerrit_config sendemail.smtpUser "${SMTP_USER}"
+    [ -z "${SMTP_PASS}" ]        || set_secure_config sendemail.smtpPass "${SMTP_PASS}"
   fi
 
 
   #Section plugins
-  git config -f "${GERRIT_SITE}/etc/gerrit.config" plugins.allowRemoteAdmin true
+  set_gerrit_config plugins.allowRemoteAdmin true
 
   #Section httpd
-  [ -z "${HTTPD_LISTENURL}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" httpd.listenUrl "${HTTPD_LISTENURL}"
+  [ -z "${HTTPD_LISTENURL}" ] || set_gerrit_config httpd.listenUrl "${HTTPD_LISTENURL}"
 
   echo "Upgrading gerrit..."
-  java -jar "${GERRIT_WAR}" init --batch -d "${GERRIT_SITE}"
+  gosu ${GERRIT_USER} java -jar "${GERRIT_WAR}" init --batch -d "${GERRIT_SITE}" ${GERRIT_INIT_ARGS}
   if [ $? -eq 0 ]; then
     echo "Upgrading is OK."
   else

--- a/gerrit-start.sh
+++ b/gerrit-start.sh
@@ -2,4 +2,4 @@
 set -e
 #TODO:Not sure if gerrit can be stopped properly...
 echo "Starting Gerrit..."
-exec $GERRIT_SITE/bin/gerrit.sh daemon
+exec gosu ${GERRIT_USER} $GERRIT_SITE/bin/gerrit.sh daemon


### PR DESCRIPTION
Most of the changes are inspired by the Postgres Docker image,
for the purpose of allowing this image to be extended like
Postgres, without keeping our own copy of gerrit-start.sh.
This is especially useful with plugins, where we want to
initialise and configure the plugins as part of the first init
call.

Specifically, the following alterations have been made:

 * Dockerfile runs wholly as root, using gosu to execute as
   ${GERRIT_USER}.
 * Added /docker-entrypoint-init.d/ directory and hook, to allow
   further customisation by other images.
 * Added $GERRIT_INIT_ARGS to the end of the gerrit init calls, to
   allow plugin installation to occur as per gerrit documentation.
 * Added documentation regarding how to extend this image.
 * Moved gerrit-entrypoint.sh and gerrit-start.sh to /, so it's harder
   to lose them when playing silly buggers with volume mounting.
 * Added set_gerrit_config and set_secure_config functions to
   gerrit-entrypoint.sh to save having gosu calls everywhere on already
   long lines.