### PR TITLE
Fix Environment variable HTTPD_LISTENURL is not reflected in gerrit.config.

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -152,9 +152,6 @@ if [ "$1" = "/gerrit-start.sh" ]; then
   #Section plugins
   set_gerrit_config plugins.allowRemoteAdmin true
 
-  #Section httpd
-  [ -z "${HTTPD_LISTENURL}" ] || set_gerrit_config httpd.listenUrl "${HTTPD_LISTENURL}"
-
   #Section gitweb
   set_gerrit_config gitweb.cgi "/usr/share/gitweb/gitweb.cgi"
 
@@ -166,5 +163,9 @@ if [ "$1" = "/gerrit-start.sh" ]; then
     echo "Something wrong..."
     cat "${GERRIT_SITE}/logs/error_log"
   fi
+
+  #Section httpd
+  [ -z "${HTTPD_LISTENURL}" ] || set_gerrit_config httpd.listenUrl "${HTTPD_LISTENURL}"
+
 fi
 exec "$@"


### PR DESCRIPTION
Hi. Thank you for your great work.

Environment variable HTTPD_LISTENURL is not reflected in gerrit.config because "gerrit init" overwrite httpd.listenUrl value.

I moved  set_gerrit_config httpd.listenUrl to after "gerrit init".  And it works.
