### PR TITLE
Upgrade to 2.13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER zsx <thinkernel@gmail.com>
 ENV GERRIT_HOME /var/gerrit
 ENV GERRIT_SITE ${GERRIT_HOME}/review_site
 ENV GERRIT_WAR ${GERRIT_HOME}/gerrit.war
-ENV GERRIT_VERSION 2.13.2
+ENV GERRIT_VERSION 2.13.3
 ENV GERRIT_USER gerrit2
 ENV GERRIT_INIT_ARGS ""
 
@@ -55,8 +55,10 @@ RUN wget \
     -O ${GERRIT_HOME}/events-log.jar
 
 #oauth2 plugin
+ENV GERRIT_OAUTH_VERSION 2.13.2
+
 RUN wget \
-    https://github.com/davido/gerrit-oauth-provider/releases/download/v${GERRIT_VERSION}/gerrit-oauth-provider.jar \
+    https://github.com/davido/gerrit-oauth-provider/releases/download/v${GERRIT_OAUTH_VERSION}/gerrit-oauth-provider.jar \
     -O ${GERRIT_HOME}/gerrit-oauth-provider.jar
 
 #download bouncy castle

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
  This image is based on the Alpine Linux project which makes this image smaller and faster than before.
 
 ## Versions
- openfrontier/gerrit:latest -> 2.13.2
+ openfrontier/gerrit:latest -> 2.13.3
 
  openfrontier/gerrit:2.12.x -> 2.12.6
 


### PR DESCRIPTION
Since the oauth plugin has not been released (yet?) for 2.13.3,
this is taking to 2.13.2.

The author is mentioning on the release notes of this plugin:
 Note: You can use this plugin version with Gerrit 2.11 release or later.
 However due some regressions, 2.13 and 2.13.1 will not work. If you
 upgrade to 2.13 line, you need 2.13.2 or later.

I tested the image and it seems to work fine.