### PR TITLE
ignore dot files and folders at initial setup step

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -20,7 +20,8 @@ if [ "$1" = "/gerrit-start.sh" ]; then
   # This obviously ensures the permissions are set correctly for when gerrit starts.
   chown -R ${GERRIT_USER} "${GERRIT_SITE}"
 
-  if [ -z "$(ls -A "$GERRIT_SITE")" ]; then
+  if [ -z "$(ls "$GERRIT_SITE")" ]; then
+    [ -e ${GERRIT_SITE}/.ssh ] && gosu ${GERRIT_USER} ln -sf ${GERRIT_SITE}/.ssh ${GERRIT_HOME}/.ssh
     echo "First time initialize gerrit..."
     gosu ${GERRIT_USER} java ${JAVA_OPTIONS} ${JAVA_MEM_OPTIONS} -jar "${GERRIT_WAR}" init --batch --no-auto-start -d "${GERRIT_SITE}" ${GERRIT_INIT_ARGS}
     #All git repositories must be removed when database is set as postgres or mysql


### PR DESCRIPTION
With AUTH_TYPE=DEVELOPMENT_BECOME_ANY_ACCOUNT gerrit creates an admin
user. gerrit is using an existing $HOME/.ssh/id_rsa.pub file to setup
the admin user with a ssh key.

A pre created .ssh folder prevents the current version of
gerrit-entrypoint.sh to start gerrit in init mode.

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>