### PR TITLE
Limit offline indexing to "accounts" index

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -173,7 +173,7 @@ if [ "$1" = "/gerrit-start.sh" ]; then
   su-exec ${GERRIT_USER} java ${JAVA_OPTIONS} ${JAVA_MEM_OPTIONS} -jar "${GERRIT_WAR}" init --batch -d "${GERRIT_SITE}" ${GERRIT_INIT_ARGS}
   if [ $? -eq 0 ]; then
     echo "Reindexing..."
-    su-exec ${GERRIT_USER} java ${JAVA_OPTIONS} ${JAVA_MEM_OPTIONS} -jar "${GERRIT_WAR}" reindex --verbose -d "${GERRIT_SITE}"
+    su-exec ${GERRIT_USER} java ${JAVA_OPTIONS} ${JAVA_MEM_OPTIONS} -jar "${GERRIT_WAR}" reindex --verbose --index accounts -d "${GERRIT_SITE}"
     echo "Upgrading is OK."
   else
     echo "Something wrong..."

--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -13,13 +13,12 @@ if [ -n "${JAVA_HEAPLIMIT}" ]; then
   JAVA_MEM_OPTIONS="-Xmx${JAVA_HEAPLIMIT}"
 fi
 
-#Initialize gerrit if gerrit site dir is empty.
-#This is necessary when gerrit site is in a volume.
 if [ "$1" = "/gerrit-start.sh" ]; then
   # If you're mounting ${GERRIT_SITE} to your host, you this will default to root.
   # This obviously ensures the permissions are set correctly for when gerrit starts.
   chown -R ${GERRIT_USER} "${GERRIT_SITE}"
 
+  # Initialize Gerrit if ${GERRIT_SITE} is empty.
   if [ -z "$(ls -A "$GERRIT_SITE")" ]; then
     echo "First time initialize gerrit..."
     su-exec ${GERRIT_USER} java ${JAVA_OPTIONS} ${JAVA_MEM_OPTIONS} -jar "${GERRIT_WAR}" init --batch --no-auto-start -d "${GERRIT_SITE}" ${GERRIT_INIT_ARGS}


### PR DESCRIPTION
Regenerating the index can delay startup substantially for large repositories, and doing so is unnecessary since version 2.11.2 when [online indexing](https://gerrit-review.googlesource.com/Documentation/cmd-index-start.html) was added.