### PR TITLE
Run initialisation if ${GERRIT_SITE}/git is empty

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -18,8 +18,8 @@ if [ "$1" = "/gerrit-start.sh" ]; then
   # This obviously ensures the permissions are set correctly for when gerrit starts.
   chown -R ${GERRIT_USER} "${GERRIT_SITE}"
 
-  # Initialize Gerrit if ${GERRIT_SITE} is empty.
-  if [ -z "$(ls -A "$GERRIT_SITE")" ]; then
+  # Initialize Gerrit if ${GERRIT_SITE}/git is empty.
+  if [ -z "$(ls -A "$GERRIT_SITE/git")" ]; then
     echo "First time initialize gerrit..."
     su-exec ${GERRIT_USER} java ${JAVA_OPTIONS} ${JAVA_MEM_OPTIONS} -jar "${GERRIT_WAR}" init --batch --no-auto-start -d "${GERRIT_SITE}" ${GERRIT_INIT_ARGS}
     #All git repositories must be removed when database is set as postgres or mysql


### PR DESCRIPTION
Run initialisation if ${GERRIT_SITE}/git is empty, this will enable configuration files to be placed in ${GERRIT_SITE} without stopping the initialisation process from running.

I noticed this issue when I tried to to mount the replication.config file as a volume in docker-compose in order for docker-gerrit to consume, i.e

````
'/opt/gerrit/replication.config:/var/gerrit/review_site/etc/replication.config',
````
However this caused docker-gerrit to exit, I believe what is happening is the initialisation is not occurring because the /var/gerrit/review_site/etc/replication.config file is already present. This causes privilege problems later on which causes the container to exit.
