### PR TITLE
Reduce gerrit start time

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -16,7 +16,7 @@ fi
 if [ "$1" = "/gerrit-start.sh" ]; then
   # If you're mounting ${GERRIT_SITE} to your host, you this will default to root.
   # This obviously ensures the permissions are set correctly for when gerrit starts.
-  chown -R ${GERRIT_USER} "${GERRIT_SITE}"
+  find "${GERRIT_SITE}/" ! -user $(id -u ${GERRIT_USER}) -exec chown ${GERRIT_USER} {} \;
 
   # Initialize Gerrit if ${GERRIT_SITE}/git is empty.
   if [ -z "$(ls -A "$GERRIT_SITE/git")" ]; then

--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -16,7 +16,7 @@ fi
 if [ "$1" = "/gerrit-start.sh" ]; then
   # If you're mounting ${GERRIT_SITE} to your host, you this will default to root.
   # This obviously ensures the permissions are set correctly for when gerrit starts.
-  find "${GERRIT_SITE}/" ! -user $(id -u ${GERRIT_USER}) -exec chown ${GERRIT_USER} {} \;
+  find "${GERRIT_SITE}/" ! -user `id -u ${GERRIT_USER}` -exec chown ${GERRIT_USER} {} \;
 
   # Initialize Gerrit if ${GERRIT_SITE}/git is empty.
   if [ -z "$(ls -A "$GERRIT_SITE/git")" ]; then


### PR DESCRIPTION
`chown -R` is too much time consuming here. Let's use `find -exec` instead