### PR TITLE
Oauth 2.14.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -fSsL \
     -o ${GERRIT_HOME}/gitiles.jar
 
 #oauth2 plugin
-ENV GERRIT_OAUTH_VERSION 2.13.6
+ENV GERRIT_OAUTH_VERSION 2.14.3
 
 RUN curl -fSsL \
     https://github.com/davido/gerrit-oauth-provider/releases/download/v${GERRIT_OAUTH_VERSION}/gerrit-oauth-provider.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN curl -fSsL https://gerrit-releases.storage.googleapis.com/gerrit-${GERRIT_VE
 
 #Download Plugins
 ENV PLUGIN_VERSION=bazel-stable-2.14
-ENV EVENTSLOG_PLUGIN_VERSION=bazel-master-stable-2.14
 ENV GERRITFORGE_URL=https://gerrit-ci.gerritforge.com
 ENV GERRITFORGE_ARTIFACT_DIR=lastSuccessfulBuild/artifact/bazel-genfiles/plugins
 
@@ -37,7 +36,7 @@ RUN curl -fSsL \
 #events-log
 #This plugin is required by gerrit-trigger plugin of Jenkins.
 RUN curl -fSsL \
-    ${GERRITFORGE_URL}/job/plugin-events-log-${EVENTSLOG_PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/events-log/events-log.jar \
+    ${GERRITFORGE_URL}/job/plugin-events-log-${PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/events-log/events-log.jar \
     -o ${GERRIT_HOME}/events-log.jar
 
 #gitiles


### PR DESCRIPTION
There was a release on Sept. 1st:
https://github.com/davido/gerrit-oauth-provider/releases/tag/v2.14.3

New features:
- @mwebber upgraded CAS provider to work against CAS 5.0+

Bug fixes:
- #87 CAS OAuth call back fails with cas 5.1.0-rc3
- #92 OAuth authentication does not work for CAS provider 5.0+

Also fixing the events-log URL as it doesn't build at the moment.