### PR TITLE
Refactor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,70 +3,24 @@ FROM openjdk:8-jre-alpine
 MAINTAINER zsx <thinkernel@gmail.com>
 
 # Overridable defaults
-ENV GERRIT_HOME /var/gerrit
-ENV GERRIT_SITE ${GERRIT_HOME}/review_site
-ENV GERRIT_WAR ${GERRIT_HOME}/gerrit.war
-ENV GERRIT_VERSION 2.14.5.1
-ENV GERRIT_USER gerrit2
-ENV GERRIT_INIT_ARGS ""
+ARG GERRIT_USER=gerrit2
+ARG GERRIT_HOME=/var/lib/gerrit
+ARG GERRIT_VERSION=2.14.5.1
+ARG PLUGIN_VERSION=bazel-stable-2.14
+ARG GERRIT_INIT_ARGS=""
+ARG GERRIT_OAUTH_VERSION=2.14.3
 
-# Add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN adduser -D -h "${GERRIT_HOME}" -g "Gerrit User" -s /sbin/nologin "${GERRIT_USER}"
+# Environment to use both at build time and at run time
+ENV \
+    GERRIT_HOME=$GERRIT_HOME \
+    GERRIT_SITE=$GERRIT_HOME/review_site \
+    GERRIT_WAR=$GERRIT_HOME/gerrit.war \
+    GERRIT_VERSION=$GERRIT_VERSION \
+    GERRIT_USER=gerrit2 \
+    GERRIT_INIT_ARGS=$GERRIT_INIT_ARGS \
+    GERRITFORGE_URL=https://gerrit-ci.gerritforge.com \
+    GERRITFORGE_ARTIFACT_DIR=lastSuccessfulBuild/artifact/buck-out/gen/plugins
 
-RUN set -x \
-    && apk add --update --no-cache git openssh openssl bash perl perl-cgi git-gitweb curl su-exec procmail
-
-RUN mkdir /docker-entrypoint-init.d
-
-#Download gerrit.war
-RUN curl -fSsL https://gerrit-releases.storage.googleapis.com/gerrit-${GERRIT_VERSION}.war -o $GERRIT_WAR
-#Only for local test
-#COPY gerrit-${GERRIT_VERSION}.war $GERRIT_WAR
-
-#Download Plugins
-ENV PLUGIN_VERSION=bazel-stable-2.14
-ENV GERRITFORGE_URL=https://gerrit-ci.gerritforge.com
-ENV GERRITFORGE_ARTIFACT_DIR=lastSuccessfulBuild/artifact/bazel-genfiles/plugins
-
-#delete-project
-RUN curl -fSsL \
-    ${GERRITFORGE_URL}/job/plugin-delete-project-${PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/delete-project/delete-project.jar \
-    -o ${GERRIT_HOME}/delete-project.jar
-
-#events-log
-#This plugin is required by gerrit-trigger plugin of Jenkins.
-RUN curl -fSsL \
-    ${GERRITFORGE_URL}/job/plugin-events-log-${PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/events-log/events-log.jar \
-    -o ${GERRIT_HOME}/events-log.jar
-
-#gitiles
-RUN curl -fSsL \
-    ${GERRITFORGE_URL}/job/plugin-gitiles-${PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/gitiles/gitiles.jar \
-    -o ${GERRIT_HOME}/gitiles.jar
-
-#oauth2 plugin
-ENV GERRIT_OAUTH_VERSION 2.14.3
-
-RUN curl -fSsL \
-    https://github.com/davido/gerrit-oauth-provider/releases/download/v${GERRIT_OAUTH_VERSION}/gerrit-oauth-provider.jar \
-    -o ${GERRIT_HOME}/gerrit-oauth-provider.jar
-
-#importer
-RUN curl -fSsL \
-    ${GERRITFORGE_URL}/job/plugin-importer-${PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/importer/importer.jar \
-    -o ${GERRIT_HOME}/importer.jar
-
-# Ensure the entrypoint scripts are in a fixed location
-COPY gerrit-entrypoint.sh /
-COPY gerrit-start.sh /
-RUN chmod +x /gerrit*.sh
-
-#A directory has to be created before a volume is mounted to it.
-#So gerrit user can own this directory.
-RUN su-exec ${GERRIT_USER} mkdir -p $GERRIT_SITE
-
-#Gerrit site directory is a volume, so configuration and repositories
-#can be persisted and survive image upgrades.
 VOLUME $GERRIT_SITE
 
 ENTRYPOINT ["/gerrit-entrypoint.sh"]
@@ -74,3 +28,42 @@ ENTRYPOINT ["/gerrit-entrypoint.sh"]
 EXPOSE 8080 29418
 
 CMD ["/gerrit-start.sh"]
+
+#Download gerrit.war
+ADD https://gerrit-releases.storage.googleapis.com/gerrit-$GERRIT_VERSION.war \
+    $GERRIT_WAR
+
+#Download Plugins
+
+#delete-project
+ADD $GERRITFORGE_URL/job/plugin-delete-project-$PLUGIN_VERSION/$GERRITFORGE_ARTIFACT_DIR/delete-project/delete-project.jar \
+    $GERRIT_SITE/plugins/
+
+#events-log
+#This plugin is required by gerrit-trigger plugin of Jenkins.
+ADD $GERRITFORGE_URL/job/plugin-events-log-$PLUGIN_VERSION/$GERRITFORGE_ARTIFACT_DIR/events-log/events-log.jar \
+    $GERRIT_SITE/plugins/
+
+#importer
+ADD $GERRITFORGE_URL/job/plugin-importer-$PLUGIN_VERSION/$GERRITFORGE_ARTIFACT_DIR/importer/importer.jar \
+    $GERRIT_SITE/plugins/
+
+#oauth2 plugin
+ADD https://github.com/davido/gerrit-oauth-provider/releases/download/v$GERRIT_OAUTH_VERSION/gerrit-oauth-provider.jar \
+    $GERRIT_HOME/gerrit-oauth-provider.jar
+
+#gitiles
+ADD $GERRITFORGE_URL/job/plugin-gitiles-$PLUGIN_VERSION/$GERRITFORGE_ARTIFACT_DIR/gitiles/gitiles.jar \
+    $GERRIT_HOME/gitiles.jar
+
+# Ensure the entrypoint scripts are in a fixed location
+COPY gerrit-entrypoint.sh gerrit-start.sh /
+
+SHELL [ "/bin/sh",  "-euxc" ]
+
+RUN \
+    apk add --update --no-cache git openssh openssl bash perl perl-cgi git-gitweb curl su-exec mysql-client ; \
+    adduser -D -h "$GERRIT_HOME" -g "Gerrit User" -s /sbin/nologin "$GERRIT_USER" ; \
+    mkdir /docker-entrypoint-init.d ; \
+    chmod +x /gerrit*.sh ; \
+    chown -R "$GERRIT_USER" "$GERRIT_SITE" "$GERRIT_HOME"

--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -38,11 +38,6 @@ if [ "$1" = "/gerrit-start.sh" ]; then
     [ ${#DATABASE_TYPE} -gt 0 ] && rm -rf "${GERRIT_SITE}/git"
   fi
 
-  # Install external plugins
-  su-exec ${GERRIT_USER} cp -f ${GERRIT_HOME}/delete-project.jar ${GERRIT_SITE}/plugins/delete-project.jar
-  su-exec ${GERRIT_USER} cp -f ${GERRIT_HOME}/events-log.jar ${GERRIT_SITE}/plugins/events-log.jar
-  su-exec ${GERRIT_USER} cp -f ${GERRIT_HOME}/importer.jar ${GERRIT_SITE}/plugins/importer.jar
-
   # Provide a way to customise this image
   echo
   for f in /docker-entrypoint-init.d/*; do


### PR DESCRIPTION
  - introduce build args to override settings using docker CLI
  - use the single ENV to reduce number of layers
  - use the single RUN to reduce number of layers
  - switch to use ADD instead of running curl
  - place plugins directly to plugin directory
  - some other cosmetic fixes