### PR TITLE
sh is not bash on debian slim

### DIFF
--- a/gerrit-entrypoint.sh
+++ b/gerrit-entrypoint.sh
@@ -47,7 +47,7 @@ if [ "$1" = "/gerrit-start.sh" ]; then
   echo
   for f in /docker-entrypoint-init.d/*; do
     case "$f" in
-      *.sh)    echo "$0: running $f"; source "$f" ;;
+      *.sh)    echo "$0: running $f"; . "$f" ;;
       *.nohup) echo "$0: running $f"; nohup  "$f" & ;;
       *)       echo "$0: ignoring $f" ;;
     esac


### PR DESCRIPTION
* `gerrit-entrypoint.sh` uses `env` to determine the shell.
* This shell in debian-slim does not recognize `source`.